### PR TITLE
Use ObjectField to streamline CollectionFieldset

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/CollectionFieldset.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/CollectionFieldset.tsx
@@ -8,7 +8,7 @@
  */
 
 import { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import { observer, useField, useForm } from '@formily/react';
+import { observer, useField, useForm, ObjectField } from '@formily/react';
 import {
   CollectionField,
   CollectionProvider_deprecated,
@@ -106,15 +106,11 @@ const CollectionFieldSet = observer(
             {fields
               .filter((field) => value && field.name in value)
               .map((field) => {
-                // constant for associations to use Input, others to use CollectionField
-                // dynamic values only support belongsTo/hasOne association, other association type should disable
                 const ConstantCompoent = ['belongsTo', 'hasOne', 'hasMany', 'belongsToMany'].includes(field.type)
                   ? AssociationInput
                   : CollectionField;
-                // TODO: try to use <ObjectField> to replace this map
-                return (
+                const FieldItem = ({ value: fieldValue, onChange: onFieldChange }) => (
                   <Form.Item
-                    key={field.name}
                     label={compile(field.uiSchema?.title ?? field.name)}
                     labelAlign="left"
                     className={css`
@@ -125,11 +121,9 @@ const CollectionFieldSet = observer(
                   >
                     <Variable.Input
                       scope={scope}
-                      value={value[field.name]}
+                      value={fieldValue}
                       changeOnSelect
-                      onChange={(next) => {
-                        onChange({ ...value, [field.name]: next });
-                      }}
+                      onChange={onFieldChange}
                     >
                       <SchemaComponent
                         schema={{
@@ -158,6 +152,7 @@ const CollectionFieldSet = observer(
                     ) : null}
                   </Form.Item>
                 );
+                return <ObjectField key={field.name} name={field.name} component={[FieldItem]} />;
               })}
             {unassignedFields.length ? (
               <Dropdown menu={menu}>


### PR DESCRIPTION
## Summary
- simplify dynamic field mapping in `CollectionFieldset` by introducing `ObjectField`

## Testing
- `yarn lint packages/plugins/@nocobase/plugin-workflow/src/client/components/CollectionFieldset.tsx` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6851728c41148332b1f8b088d786b501