### PR TITLE
Use helper for ConditionInstruction job

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/ConditionInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/ConditionInstruction.ts
@@ -13,6 +13,7 @@ import type Processor from '../Processor';
 import { JOB_STATUS } from '../constants';
 import type { FlowNodeModel, JobModel } from '../types';
 import { logicCalculate } from '../logicCalculate';
+import { buildJob } from '../utils';
 
 export const BRANCH_INDEX = {
   DEFAULT: null,
@@ -45,14 +46,10 @@ export class ConditionInstruction extends Instruction {
       };
     }
 
-    const job = {
+    const job = buildJob(node, prevJob, {
       status: JOB_STATUS.RESOLVED,
       result,
-      // TODO(optimize): try unify the building of job
-      nodeId: node.id,
-      nodeKey: node.key,
-      upstreamId: (prevJob && prevJob.id) || null,
-    };
+    });
 
     const branchNode = processor.nodes.find(
       (item) => item.upstreamId === node.id && item.branchIndex != null && Boolean(item.branchIndex) === result,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
@@ -8,6 +8,7 @@
  */
 
 import { Model } from '@nocobase/database';
+import type { FlowNodeModel, JobModel } from './types';
 
 export function toJSON(data: any): any {
   if (Array.isArray(data)) {
@@ -23,4 +24,17 @@ export function toJSON(data: any): any {
     }
   });
   return result;
+}
+
+export function buildJob(
+  node: FlowNodeModel,
+  prevJob?: JobModel | null,
+  payload: Record<string, any> = {},
+): Record<string, any> {
+  return {
+    nodeId: node.id,
+    nodeKey: node.key,
+    upstreamId: prevJob?.id ?? null,
+    ...payload,
+  };
 }


### PR DESCRIPTION
## Summary
- provide `buildJob` helper for consistent job creation
- refactor `ConditionInstruction` to use `buildJob`

## Testing
- `yarn lint packages/plugins/@nocobase/plugin-workflow/src/server/instructions/ConditionInstruction.ts packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6851727d8544833296dcb2704f4e6124