### PR TITLE
Fix getVersion JSON parsing

### DIFF
--- a/packages/core/cli/src/util.js
+++ b/packages/core/cli/src/util.js
@@ -179,9 +179,18 @@ exports.updateJsonFile = async (target, fn) => {
 };
 
 exports.getVersion = async () => {
-  const { stdout } = await execa('npm', ['v', '@nocobase/app-server', 'versions']);
-  const versions = new Function(`return (${stdout})`)();
-  return versions[versions.length - 1];
+  const { stdout } = await execa('npm', [
+    'view',
+    '@nocobase/app-server',
+    'versions',
+    '--json',
+  ]);
+  try {
+    const versions = JSON.parse(stdout);
+    return versions[versions.length - 1];
+  } catch (error) {
+    return '';
+  }
 };
 
 exports.generateAppDir = function generateAppDir() {


### PR DESCRIPTION
## Summary
- update `getVersion` in CLI utils to query npm with `--json`
- parse npm output using `JSON.parse` and guard with try/catch

## Testing
- `npx eslint@8 -c .eslintrc packages/core/cli/src/util.js` *(fails: missing plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6852cb81c5f48332961741ae3da5ac59