### PR TITLE
Replace console.log with logger in server

### DIFF
--- a/packages/core/server/src/app-supervisor.ts
+++ b/packages/core/server/src/app-supervisor.ts
@@ -12,6 +12,7 @@ import { Mutex } from 'async-mutex';
 import { EventEmitter } from 'events';
 import Application, { ApplicationOptions, MaintainingCommandStatus } from './application';
 import { getErrorLevel } from './errors/handler';
+import { logger } from '@nocobase/logger';
 
 type BootOptions = {
   appName: string;
@@ -221,7 +222,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
 
   async removeApp(appName: string) {
     if (!this.apps[appName]) {
-      console.log(`app ${appName} not exists`);
+      logger.warn(`app ${appName} not exists`);
       return;
     }
 

--- a/packages/core/server/src/commands/console.ts
+++ b/packages/core/server/src/commands/console.ts
@@ -22,7 +22,7 @@ export default (app: Application) => {
       const repl = (REPL.start('nocobase > ').context.app = app);
       repl.on('exit', async function (err) {
         if (err) {
-          console.log(err);
+          app.log.error(err);
           process.exit(1);
         }
         await app.stop();

--- a/packages/core/server/src/commands/db-clean.ts
+++ b/packages/core/server/src/commands/db-clean.ts
@@ -17,7 +17,7 @@ export default (app: Application) => {
     .auth()
     .option('-y, --yes')
     .action(async (opts) => {
-      console.log('Clearing database');
+      app.log.info('Clearing database');
       await app.db.clean({
         drop: opts.yes,
       });

--- a/packages/core/server/src/commands/db-sync.ts
+++ b/packages/core/server/src/commands/db-sync.ts
@@ -18,7 +18,7 @@ export default (app: Application) => {
     .preload()
     .action(async (...cliArgs) => {
       const [opts] = cliArgs;
-      console.log('db sync...');
+      app.log.info('db sync...');
 
       const Collection = app.db.getCollection('collections');
       if (Collection) {

--- a/packages/core/server/src/commands/migrator.ts
+++ b/packages/core/server/src/commands/migrator.ts
@@ -16,7 +16,7 @@ export default (app: Application) => {
     .command('migrator')
     .preload()
     .action(async (opts) => {
-      console.log('migrating...');
+      app.log.info('migrating...');
       await app.emitAsync('cli.beforeMigrator', opts);
       await app.db.migrator.runAsCLI(process.argv.slice(3));
       await app.stop();

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { createSystemLogger, getLoggerFilePath, SystemLogger } from '@nocobase/logger';
+import { createSystemLogger, getLoggerFilePath, SystemLogger, logger } from '@nocobase/logger';
 import { Registry, Toposort, ToposortOptions, uid } from '@nocobase/utils';
 import { createStoragePluginsSymlink } from '@nocobase/utils/plugin-symlink';
 import { Command } from 'commander';
@@ -244,7 +244,7 @@ export class Gateway extends EventEmitter {
     try {
       handleApp = await this.getRequestHandleAppName(req as IncomingRequest);
     } catch (error) {
-      console.log(error);
+      this.getLogger(handleApp, res).error(error);
       this.responseErrorWithCode('APP_INITIALIZING', res, { appName: handleApp });
       return;
     }
@@ -437,7 +437,7 @@ export class Gateway extends EventEmitter {
     }
 
     if (this.port === null) {
-      console.log('gateway port is not set, http server will not start');
+      logger.warn('gateway port is not set, http server will not start');
       return;
     }
 
@@ -458,7 +458,7 @@ export class Gateway extends EventEmitter {
     });
 
     this.server.listen(this.port, this.host, () => {
-      console.log(`Gateway HTTP Server running at http://${this.host}:${this.port}/`);
+      logger.info(`Gateway HTTP Server running at http://${this.host}:${this.port}/`);
       if (options?.callback) {
         options.callback(this.server);
       }

--- a/packages/core/server/src/gateway/ipc-socket-server.ts
+++ b/packages/core/server/src/gateway/ipc-socket-server.ts
@@ -14,6 +14,7 @@ import path from 'path';
 import xpipe from 'xpipe';
 import { AppSupervisor } from '../app-supervisor';
 import { writeJSON } from './ipc-socket-client';
+import { logger } from '@nocobase/logger';
 
 export class IPCSocketServer {
   socketServer: net.Server;
@@ -35,10 +36,10 @@ export class IPCSocketServer {
     }
 
     const socketServer = net.createServer((c) => {
-      console.log('client connected');
+      logger.debug('client connected');
 
       c.on('end', () => {
-        console.log('client disconnected');
+        logger.debug('client disconnected');
       });
 
       c.on('data', (data) => {
@@ -75,7 +76,7 @@ export class IPCSocketServer {
     });
 
     socketServer.listen(xpipe.eq(socketPath), () => {
-      console.log(`Gateway IPC Server running at ${socketPath}`);
+      logger.info(`Gateway IPC Server running at ${socketPath}`);
     });
 
     return new IPCSocketServer(socketServer);
@@ -98,7 +99,7 @@ export class IPCSocketServer {
           }
         }, 500);
       });
-      console.log('status', status);
+      logger.debug('status', status);
       return status;
     }
     // console.log(`cli received message ${type}`);

--- a/packages/core/server/src/gateway/ws-server.ts
+++ b/packages/core/server/src/gateway/ws-server.ts
@@ -14,7 +14,7 @@ import { IncomingMessage } from 'http';
 import { AppSupervisor } from '../app-supervisor';
 import { applyErrorWithArgs, getErrorWithCode } from './errors';
 import lodash from 'lodash';
-import { Logger } from '@nocobase/logger';
+import { Logger, logger } from '@nocobase/logger';
 import EventEmitter from 'events';
 import { parse } from 'url';
 
@@ -48,7 +48,7 @@ export class WSServer extends EventEmitter {
     this.wss.on('connection', (ws: WebSocketWithId, request: IncomingMessage) => {
       const client = this.addNewConnection(ws, request);
 
-      console.log(`new client connected ${ws.id}`);
+      logger.info(`new client connected ${ws.id}`);
 
       ws.on('error', () => {
         this.removeConnection(ws.id);
@@ -226,7 +226,7 @@ export class WSServer extends EventEmitter {
       return;
     }
     client.tags.add(`${tagKey}#${tagValue}`);
-    console.log(`client tags: ${Array.from(client.tags)}`);
+    logger.debug(`client tags: ${Array.from(client.tags)}`);
   }
 
   removeClientTag(clientId: string, tagKey: string) {
@@ -248,7 +248,7 @@ export class WSServer extends EventEmitter {
     const handleAppName = await Gateway.getInstance().getRequestHandleAppName(req);
 
     client.app = handleAppName;
-    console.log(`client tags: app#${handleAppName}`);
+    logger.debug(`client tags: app#${handleAppName}`);
     client.tags.add(`app#${handleAppName}`);
 
     const hasApp = AppSupervisor.getInstance().hasApp(handleAppName);
@@ -259,7 +259,7 @@ export class WSServer extends EventEmitter {
   }
 
   removeConnection(id: string) {
-    console.log(`client disconnected ${id}`);
+    logger.info(`client disconnected ${id}`);
     this.webSocketClients.delete(id);
   }
 

--- a/packages/core/server/src/plugin-manager/plugin-manager-repository.ts
+++ b/packages/core/server/src/plugin-manager/plugin-manager-repository.ts
@@ -8,6 +8,7 @@
  */
 
 import Topo from '@hapi/topo';
+import { logger } from '@nocobase/logger';
 import { Repository } from '@nocobase/database';
 import { default as _, default as lodash } from 'lodash';
 import { PluginManager } from './plugin-manager';
@@ -105,12 +106,12 @@ export class PluginManagerRepository extends Repository {
     name = lodash.cloneDeep(name);
 
     const pluginNames = lodash.castArray(name);
-    console.log(`disable ${name}, ${pluginNames}`);
+    logger.debug(`disable ${name}, ${pluginNames}`);
     const filter = {
       name,
     };
 
-    console.log(JSON.stringify(filter, null, 2));
+    logger.trace(JSON.stringify(filter, null, 2));
     await this.update({
       filter,
       values: {

--- a/packages/core/server/src/plugin-manager/plugin-manager.ts
+++ b/packages/core/server/src/plugin-manager/plugin-manager.ts
@@ -16,6 +16,7 @@ import fs from 'fs-extra';
 import _ from 'lodash';
 import net from 'net';
 import { basename, join, resolve, sep } from 'path';
+import { logger } from '@nocobase/logger';
 import Application from '../application';
 import { createAppProxy, tsxRerunning } from '../helper';
 import { Plugin } from '../plugin';
@@ -166,16 +167,16 @@ export class PluginManager {
       const packageName = this.getPackageName(name);
       return packageName;
     } catch (error) {
-      console.log(`\`${name}\` plugin not found locally`);
+      logger.info(`\`${name}\` plugin not found locally`);
       const prefixes = this.getPluginPkgPrefix();
       for (const prefix of prefixes) {
         try {
           const packageName = `${prefix}${name}`;
-          console.log(`Try to find ${packageName}`);
+          logger.info(`Try to find ${packageName}`);
           await execa('npm', ['v', packageName, 'versions']);
-          console.log(`${packageName} downloading`);
+          logger.info(`${packageName} downloading`);
           await execa('yarn', ['add', packageName, '-W']);
-          console.log(`${packageName} downloaded`);
+          logger.info(`${packageName} downloaded`);
           return packageName;
         } catch (error) {
           continue;
@@ -748,7 +749,7 @@ export class PluginManager {
           const dir = resolve(process.env.NODE_MODULES_PATH, plugin.packageName);
           try {
             const realDir = await fs.realpath(dir);
-            console.log('realDir', realDir);
+            this.app.log.debug('realDir %s', realDir);
             this.app.log.debug(`rm -rf ${realDir}`);
             return fs.rm(realDir, { force: true, recursive: true });
           } catch (error) {


### PR DESCRIPTION
## Summary
- use the project logger across `packages/core/server`
- remove leftover debug logging in plugin manager

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6852cd04b848833285b639ed9db1e5f7