### PR TITLE
Improve HTML sanitization

### DIFF
--- a/packages/core/client/src/api-client/APIClient.ts
+++ b/packages/core/client/src/api-client/APIClient.ts
@@ -12,6 +12,7 @@ import { Result } from 'ahooks/es/useRequest/src/types';
 import { notification } from 'antd';
 import React from 'react';
 import { Application } from '../application';
+import { parseHTMLToText } from '../common';
 
 function notify(type, messages, instance) {
   if (!messages?.length) {
@@ -137,9 +138,7 @@ export class APIClient extends APIClientSDK {
 
   toErrMessages(error) {
     if (typeof error?.response?.data === 'string') {
-      const tempElement = document.createElement('div');
-      tempElement.innerHTML = error?.response?.data;
-      let message = tempElement.textContent || tempElement.innerText;
+      let message = parseHTMLToText(error?.response?.data);
       if (message.includes('Error occurred while trying')) {
         message = 'The application may be starting up. Please try again later.';
         return [{ code: 'APP_WARNING', message }];

--- a/packages/core/client/src/common/index.ts
+++ b/packages/core/client/src/common/index.ts
@@ -11,3 +11,4 @@ export * from './AppNotFound';
 export * from './SelectWithTitle';
 export * from './useFieldComponentName';
 export * from './getVariableValue';
+export * from '../utils/sanitize';

--- a/packages/core/client/src/pm/PluginDocument.tsx
+++ b/packages/core/client/src/pm/PluginDocument.tsx
@@ -15,6 +15,7 @@ import { useStyles as useMarkdownStyles } from '../schema-component/antd/markdow
 import { useParseMarkdown } from '../schema-component/antd/markdown/util';
 import { useStyles } from './style';
 import { useGlobalTheme } from '../global-theme';
+import { sanitizeHTMLString } from '../common';
 
 const PLUGIN_STATICS_PATH = '/static/plugins/';
 
@@ -48,7 +49,7 @@ export const PluginDocument: React.FC<PluginDocumentProps> = memo((props) => {
         if (src.startsWith('http') || src.startsWith('//:')) return match;
         return `src="${PLUGIN_STATICS_PATH}${packageName}/${src}"`;
       });
-      return res;
+      return sanitizeHTMLString(res);
     }
     return '';
   }, [html, packageName]);

--- a/packages/core/client/src/powered-by/index.tsx
+++ b/packages/core/client/src/powered-by/index.tsx
@@ -9,6 +9,7 @@
 
 import { css, cx } from '@emotion/css';
 import { parseHTML } from '@nocobase/utils/client';
+import { sanitizeHTMLString } from '../common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCurrentAppInfo } from '../appInfo/CurrentAppInfoProvider';
@@ -36,16 +37,16 @@ export const PoweredBy = () => {
   `;
   const appVersion = `<span class="nb-app-version">v${data?.data?.version}</span>`;
 
+  const html = parseHTML(
+    customBrandPlugin?.options?.options?.brand ||
+      `Powered by <a href="${urls[i18n.language] || urls['en-US']}" target="_blank">NocoBase</a>`,
+    { appVersion },
+  );
+
   return (
     <div
       className={cx(style, 'nb-brand')}
-      dangerouslySetInnerHTML={{
-        __html: parseHTML(
-          customBrandPlugin?.options?.options?.brand ||
-            `Powered by <a href="${urls[i18n.language] || urls['en-US']}" target="_blank">NocoBase</a>`,
-          { appVersion },
-        ),
-      }}
+      dangerouslySetInnerHTML={{ __html: sanitizeHTMLString(html) }}
     ></div>
   );
 };

--- a/packages/core/client/src/schema-component/antd/markdown/Markdown.Void.tsx
+++ b/packages/core/client/src/schema-component/antd/markdown/Markdown.Void.tsx
@@ -18,6 +18,7 @@ import { useCompile } from '../../';
 import { useCollectionRecord } from '../../../data-source';
 import { FlagProvider, useFlag } from '../../../flag-provider';
 import { useGlobalTheme } from '../../../global-theme';
+import { sanitizeHTMLString } from '../../../common';
 import { withDynamicSchemaProps } from '../../../hoc/withDynamicSchemaProps';
 import { useVariableOptions } from '../../../schema-settings/VariableInput/hooks/useVariableOptions';
 import { useLocalVariables, useVariables } from '../../../variables';
@@ -203,7 +204,7 @@ export const MarkdownVoidInner: any = withDynamicSchemaProps(
       <div
         className={cls([componentCls, hashId, 'nb-markdown nb-markdown-default nb-markdown-table', className])}
         style={{ ...props.style, height: height || '100%', overflowY: height ? 'auto' : 'null' }}
-        dangerouslySetInnerHTML={{ __html: html }}
+        dangerouslySetInnerHTML={{ __html: sanitizeHTMLString(html) }}
       />
     );
   }),

--- a/packages/core/client/src/schema-component/antd/markdown/Markdown.tsx
+++ b/packages/core/client/src/schema-component/antd/markdown/Markdown.tsx
@@ -16,6 +16,7 @@ import { ReadPretty as InputReadPretty } from '../input';
 import { MarkdownVoid } from './Markdown.Void';
 import { useStyles } from './style';
 import { convertToText, useParseMarkdown } from './util';
+import { sanitizeHTMLString } from '../../../common';
 
 export const Markdown: any = connect(
   AntdInput.TextArea,
@@ -45,7 +46,7 @@ export const MarkdownReadPretty = (props) => {
   const value = (
     <div
       className={`${hashId} ${className} nb-markdown nb-markdown-default nb-markdown-table`}
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: sanitizeHTMLString(html) }}
     />
   );
 

--- a/packages/core/client/src/user/Help.tsx
+++ b/packages/core/client/src/user/Help.tsx
@@ -11,6 +11,7 @@ import { QuestionCircleOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
 import { observer } from '@formily/reactive-react';
 import { parseHTML } from '@nocobase/utils/client';
+import { sanitizeHTMLString } from '../common';
 import { Dropdown, Menu, Popover } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -125,7 +126,9 @@ export const Help = observer(
 
     if (customBrandPlugin?.options?.options?.about) {
       const appVersion = `<span class="nb-app-version">v${data?.data?.version}</span>`;
-      const content = parseHTML(customBrandPlugin.options.options.about, { appVersion });
+      const content = sanitizeHTMLString(
+        parseHTML(customBrandPlugin.options.options.about, { appVersion }),
+      );
 
       return (
         <div className={helpClassName}>

--- a/packages/core/client/src/utils/__tests__/sanitize.test.ts
+++ b/packages/core/client/src/utils/__tests__/sanitize.test.ts
@@ -1,0 +1,17 @@
+import { sanitizeHTMLString, parseHTMLToText } from '../sanitize';
+
+describe('sanitizeHTMLString', () => {
+  it('removes script tags and event attributes', () => {
+    const html = '<img src="x" onerror="alert(1)"/><script>alert(2)</script><div>ok</div>';
+    const result = sanitizeHTMLString(html);
+    expect(result).toBe('<img src="x"><div>ok</div>');
+  });
+});
+
+describe('parseHTMLToText', () => {
+  it('parses html to plain text without scripts', () => {
+    const html = '<div>Hello<script>alert(1)</script>World</div>';
+    const result = parseHTMLToText(html);
+    expect(result).toBe('HelloWorld');
+  });
+});

--- a/packages/core/client/src/utils/sanitize.ts
+++ b/packages/core/client/src/utils/sanitize.ts
@@ -1,0 +1,22 @@
+export function parseHTMLToText(html: string): string {
+  if (!html) return '';
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  doc.querySelectorAll('script,style').forEach((el) => el.remove());
+  return doc.body.textContent || '';
+}
+
+export function sanitizeHTMLString(html: string): string {
+  if (!html) return '';
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  doc.querySelectorAll('script,style').forEach((el) => el.remove());
+  doc.querySelectorAll('*').forEach((el) => {
+    Array.from(el.attributes).forEach((attr) => {
+      if (attr.name.startsWith('on')) {
+        el.removeAttribute(attr.name);
+      }
+    });
+  });
+  return doc.body.innerHTML;
+}


### PR DESCRIPTION
## Summary
- sanitize raw HTML before injecting into DOM
- add DOMParser utilities for HTML cleaning
- sanitize plugin docs, help popups, markdown preview and brand info
- test DOM sanitization utilities

## Testing
- `npx vitest run packages/core/client/src/utils/__tests__/sanitize.test.ts` *(fails: needs vitest install)*

------
https://chatgpt.com/codex/tasks/task_e_6852cd08b30c8332a75d21b4949ca2e5