### PR TITLE
Fix dateRangeUtils tests

### DIFF
--- a/packages/core/utils/src/__tests__/dateRangeUtils.test.ts
+++ b/packages/core/utils/src/__tests__/dateRangeUtils.test.ts
@@ -10,6 +10,7 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import { vi } from 'vitest';
 import { getDayRangeByParams } from '../client';
 
 dayjs.extend(utc);
@@ -62,8 +63,14 @@ describe('getDayRangeByParams', () => {
   });
 });
 
-const originalDateNow = Date.now;
-Date.now = () => mockNow.valueOf();
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(mockNow.toDate());
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
 
 const cases = [
   {
@@ -190,5 +197,3 @@ describe('getOffsetRangeByParams', () => {
   });
 });
 
-// 恢复 Date.now
-Date.now = originalDateNow;


### PR DESCRIPTION
## Summary
- fix dateRangeUtils.test by mocking system time with Vitest

## Testing
- `node node_modules/.bin/nocobase test packages/core/utils/src/__tests__/dateRangeUtils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6852d55ee4148332acb3110bbbeb5c2e