### PR TITLE
Fix type for logger message padding

### DIFF
--- a/packages/core/logger/src/format.ts
+++ b/packages/core/logger/src/format.ts
@@ -125,7 +125,7 @@ export const consoleFormat: winston.Logform.Format = winston.format.printf((info
     .join(' ');
 
   const level = `[${info.level}]`.padEnd(7, ' ');
-  const message = info.message.padEnd(44, ' ');
+  const message = String(info.message).padEnd(44, ' ');
   const color =
     {
       error: chalk.red,


### PR DESCRIPTION
## Summary
- fix build error in logger `consoleFormat`

## Testing
- `yarn build` *(fails: command not found: nocobase)*

------
https://chatgpt.com/codex/tasks/task_e_6852e07bfee88332b5fa29136c17c00a